### PR TITLE
Add more logging to troubleshooting puppet-plugin report issues

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/puppet/track/RootActionImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/puppet/track/RootActionImpl.java
@@ -9,7 +9,10 @@ import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Exposed at /puppet to receive report submissions from puppet over HTTP.
@@ -36,13 +39,27 @@ public class RootActionImpl implements RootAction {
     @RequirePOST
     public HttpResponse doReport(StaplerRequest req) throws IOException {
         // TODO: stapler YAML support
-
-        PuppetReport.load(req.getReader()).process();
-
+        LOGGER.log(Level.FINE, "Puppet plugin has received a report from {0}", req.getRemoteAddr());
+        try {
+            BufferedReader bufferedreader = req.getReader();
+            if (bufferedreader!=null) {
+                PuppetReport puppetReport = PuppetReport.load(bufferedreader);
+                puppetReport.process();
+            } else {
+                LOGGER.log(Level.WARNING, "Ignoring empty PuppetReport sent by {0}", req.getRemoteAddr());
+            }
+        } catch (IOException e)  {
+            LOGGER.log(Level.WARNING, String.format("PuppetReport error loading report sent by %s", req.getRemoteAddr()), e);
+            throw new IOException();
+        } catch (NullPointerException e)  {
+            LOGGER.log(Level.WARNING, String.format("PuppetReport error loading report sent by %s", req.getRemoteAddr()), e);
+        }
         return HttpResponses.ok();
     }
 
     public static RootActionImpl get() {
         return Jenkins.getInstance().getExtensionList(RootAction.class).get(RootActionImpl.class);
     }
+
+    private static final Logger LOGGER = Logger.getLogger(RootActionImpl.class.getName());
 }


### PR DESCRIPTION
Right now there is not any logging created to know if `puppet-plugin` received, or not, any report from a host. With this simple enhancement you will know if it has received a report and if there was an issue reading the report. I think this will be useful for troubleshooting purposes.

@reviewbybees @ndeloof @alecharp 