### PR TITLE
Update deployment-notification

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>deployment-notification</artifactId>
-      <version>1.0</version>
+      <version>1.1</version>
     </dependency>
     <dependency>
         <groupId>org.yaml</groupId>


### PR DESCRIPTION
Update deployment-notification to version `1.1` to avoid the exception below:

```
Caused by: java.lang.ClassNotFoundException: org.jenkinsci.plugins.deployment.promoted_builds.DeploymentPromotionCondition$DescriptorImpl
	at hudson.PluginManager$UberClassLoader.findClass(PluginManager.java:942)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	at net.java.sezpoz.IndexItem.element(IndexItem.java:134)
	... 26 more
```

New  version add the `@Extension(optional=true)`

```
@Extension(optional=true)
     public static final class DescriptorImpl extends PromotionConditionDescriptor
```