### PR TITLE
Use UnprotectedRootActionImpl

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>deployment-notification</artifactId>
-      <version>1.0</version>
+      <version>1.1</version>
     </dependency>
     <dependency>
         <groupId>org.yaml</groupId>

--- a/src/main/java/org/jenkinsci/plugins/puppet/track/UnprotectedRootActionImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/puppet/track/UnprotectedRootActionImpl.java
@@ -1,7 +1,7 @@
 package org.jenkinsci.plugins.puppet.track;
 
 import hudson.Extension;
-import hudson.model.RootAction;
+import hudson.model.UnprotectedRootAction;
 import hudson.util.HttpResponses;
 import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.puppet.track.report.PuppetReport;
@@ -17,7 +17,7 @@ import java.io.IOException;
  * @author Kohsuke Kawaguchi
  */
 @Extension
-public class RootActionImpl implements RootAction {
+public class UnprotectedRootActionImpl implements UnprotectedRootAction {
     public String getIconFileName() {
         return null;
     }
@@ -42,7 +42,7 @@ public class RootActionImpl implements RootAction {
         return HttpResponses.ok();
     }
 
-    public static RootActionImpl get() {
-        return Jenkins.getInstance().getExtensionList(RootAction.class).get(RootActionImpl.class);
+    public static UnprotectedRootActionImpl get() {
+        return Jenkins.getInstance().getExtensionList(UnprotectedRootAction.class).get(UnprotectedRootActionImpl.class);
     }
 }


### PR DESCRIPTION
Other jenkins web-hook are designed to work without authentication and I think that for simplification the `puppet-plugin` should do the same. As far as I know, there is not a security issue to expose with this change and it makes the integration easier.

This enhancement is beneficial for cases in which puppet is reporting to multiple Jenkins environment, in this way, you don't need to end up using a different `API_TOKEN` for each user in each instance. 

```
sudo puppet apply /etc/puppet/modules/deploy-petclinic/tests/init.pp --reports http --reporturl=http://<USER>:<TOKEN>@<JENKINS_URL>/puppet/report
```

@reviewbybees